### PR TITLE
feat: Improve form input text contrast

### DIFF
--- a/components/CardModal.tsx
+++ b/components/CardModal.tsx
@@ -1183,7 +1183,7 @@ export default function CardModal({ card, onClose, permissionType, onUpdateChofe
                                   const option = availableChofers.find(opt => opt.name === e.target.value);
                                   setChoferEmail(option?.email || '');
                                 }}
-                                className="w-full p-3 border border-red-300/50 rounded-lg text-sm focus:ring-2 focus:ring-[#FF355A]/50 focus:border-[#FF355A] bg-white/80 backdrop-blur-sm shadow-sm transition-all duration-200"
+                                className="w-full p-3 border border-red-300/50 rounded-lg text-sm focus:ring-2 focus:ring-[#FF355A]/50 focus:border-[#FF355A] bg-white/80 backdrop-blur-sm shadow-sm transition-all duration-200 text-black"
                               >
                                 <option value="">Selecione um nome...</option>
                                 {availableChofers.map(option => (
@@ -1351,7 +1351,7 @@ export default function CardModal({ card, onClose, permissionType, onUpdateChofe
                                 const option = availableChofers.find(opt => opt.name === e.target.value);
                                 setAllocateDriverEmail(option?.email || '');
                               }}
-                              className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white shadow-sm transition-all duration-200"
+                              className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white shadow-sm transition-all duration-200 text-black"
                             >
                               <option value="">Selecione um chofer...</option>
                               {availableChofers.map(option => (
@@ -1370,7 +1370,7 @@ export default function CardModal({ card, onClose, permissionType, onUpdateChofe
                                 type="date" 
                                 value={collectionDate}
                                 onChange={(e) => setCollectionDate(e.target.value)}
-                                className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white shadow-sm transition-all duration-200"
+                                className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white shadow-sm transition-all duration-200 text-black"
                               />
                             </div>
                             <div>
@@ -1381,7 +1381,7 @@ export default function CardModal({ card, onClose, permissionType, onUpdateChofe
                                 type="time" 
                                 value={collectionTime}
                                 onChange={(e) => setCollectionTime(e.target.value)}
-                                className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white shadow-sm transition-all duration-200"
+                                className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white shadow-sm transition-all duration-200 text-black"
                               />
                             </div>
                           </div>
@@ -1394,7 +1394,7 @@ export default function CardModal({ card, onClose, permissionType, onUpdateChofe
                             <select 
                               value={billingType}
                               onChange={(e) => setBillingType(e.target.value)}
-                              className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white shadow-sm transition-all duration-200"
+                              className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white shadow-sm transition-all duration-200 text-black"
                             >
                               <option value="">Selecione o tipo...</option>
                               <option value="avulso">Avulso</option>
@@ -1421,7 +1421,7 @@ export default function CardModal({ card, onClose, permissionType, onUpdateChofe
                                   setCollectionValue(formatted);
                                 }}
                                 placeholder="R$ 0,00"
-                                className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white shadow-sm transition-all duration-200"
+                                className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white shadow-sm transition-all duration-200 text-black placeholder-gray-600"
                               />
                             </div>
                           )}
@@ -1444,7 +1444,7 @@ export default function CardModal({ card, onClose, permissionType, onUpdateChofe
                                 setAdditionalKm(formatted);
                               }}
                               placeholder="R$ 0,00"
-                              className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white shadow-sm transition-all duration-200"
+                              className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white shadow-sm transition-all duration-200 text-black placeholder-gray-600"
                             />
                           </div>
 
@@ -1507,7 +1507,7 @@ export default function CardModal({ card, onClose, permissionType, onUpdateChofe
                         <select 
                           value={rejectionReason}
                           onChange={(e) => setRejectionReason(e.target.value)}
-                          className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-red-500/50 focus:border-red-500 bg-white shadow-sm transition-all duration-200"
+                          className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-red-500/50 focus:border-red-500 bg-white shadow-sm transition-all duration-200 text-black"
                         >
                           <option value="">Selecione um motivo...</option>
                           <option value="cliente_pagamento">Cliente realizou pagamento</option>
@@ -1528,7 +1528,7 @@ export default function CardModal({ card, onClose, permissionType, onUpdateChofe
                           onChange={(e) => setRejectionObservations(e.target.value)}
                           rows={4}
                           placeholder="Descreva detalhes adicionais sobre a rejeição..."
-                          className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-red-500/50 focus:border-red-500 bg-white shadow-sm transition-all duration-200 resize-none"
+                          className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-red-500/50 focus:border-red-500 bg-white shadow-sm transition-all duration-200 resize-none text-black placeholder-gray-600"
                         />
                       </div>
 
@@ -1735,7 +1735,7 @@ export default function CardModal({ card, onClose, permissionType, onUpdateChofe
                                         setPatioExpenseValues(prev => ({ ...prev, [expense.key]: formatted }));
                                       }}
                                       placeholder="R$ 0,00"
-                                      className="w-full p-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500"
+                                      className="w-full p-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 text-black placeholder-gray-600"
                                     />
                                   </div>
                                   <div>
@@ -1896,7 +1896,7 @@ export default function CardModal({ card, onClose, permissionType, onUpdateChofe
                                         setTowedExpenseValues(prev => ({ ...prev, [expense.key]: formatted }));
                                       }}
                                       placeholder="R$ 0,00"
-                                      className="w-full p-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-orange-500/50 focus:border-orange-500"
+                                      className="w-full p-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-orange-500/50 focus:border-orange-500 text-black placeholder-gray-600"
                                     />
                                   </div>
                                   <div>
@@ -1988,7 +1988,7 @@ export default function CardModal({ card, onClose, permissionType, onUpdateChofe
                           onChange={(e) => setMechanicalTowReason(e.target.value)}
                           rows={6}
                           placeholder="Descreva detalhadamente os problemas mecânicos identificados após o pedido de desbloqueio que justificam a necessidade do guincho..."
-                          className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-red-500/50 focus:border-red-500 bg-white shadow-sm transition-all duration-200 resize-none"
+                          className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-red-500/50 focus:border-red-500 bg-white shadow-sm transition-all duration-200 resize-none text-black placeholder-gray-600"
                         />
                       </div>
 
@@ -2157,7 +2157,7 @@ export default function CardModal({ card, onClose, permissionType, onUpdateChofe
                           onChange={(e) => setUnlockObservations(e.target.value)}
                           rows={3}
                           placeholder="Observações adicionais sobre o desbloqueio..."
-                          className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 bg-white shadow-sm transition-all duration-200 resize-none"
+                          className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 bg-white shadow-sm transition-all duration-200 resize-none text-black placeholder-gray-600"
                         />
                       </div>
 
@@ -2219,7 +2219,7 @@ export default function CardModal({ card, onClose, permissionType, onUpdateChofe
                         <select 
                           value={towingReason}
                           onChange={(e) => setTowingReason(e.target.value)}
-                          className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-orange-500/50 focus:border-orange-500 bg-white shadow-sm transition-all duration-200"
+                          className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-orange-500/50 focus:border-orange-500 bg-white shadow-sm transition-all duration-200 text-black"
                         >
                           <option value="">Selecione um motivo...</option>
                           <option value="Veículo com avarias / problemas mecânicos">Veículo com avarias / problemas mecânicos</option>
@@ -2283,7 +2283,7 @@ export default function CardModal({ card, onClose, permissionType, onUpdateChofe
                           onChange={(e) => setTowingObservations(e.target.value)}
                           rows={3}
                           placeholder="Observações adicionais sobre a solicitação de guincho..."
-                          className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-orange-500/50 focus:border-orange-500 bg-white shadow-sm transition-all duration-200 resize-none"
+                          className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-orange-500/50 focus:border-orange-500 bg-white shadow-sm transition-all duration-200 resize-none text-black placeholder-gray-600"
                         />
                       </div>
 
@@ -2344,7 +2344,7 @@ export default function CardModal({ card, onClose, permissionType, onUpdateChofe
                         <select 
                           value={problemType}
                           onChange={(e) => setProblemType(e.target.value)}
-                          className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-purple-500/50 focus:border-purple-500 bg-white shadow-sm transition-all duration-200"
+                          className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-purple-500/50 focus:border-purple-500 bg-white shadow-sm transition-all duration-200 text-black"
                         >
                           <option value="">Selecione uma dificuldade...</option>
                           <option value="Cliente regularizou o pagamento">Cliente regularizou o pagamento</option>

--- a/components/MobileTaskModal.tsx
+++ b/components/MobileTaskModal.tsx
@@ -1221,7 +1221,7 @@ export default function MobileTaskModal({ card, isOpen, onClose, permissionType,
                                   const option = availableChofers.find(opt => opt.name === e.target.value);
                                   setChoferEmail(option?.email || '');
                                 }}
-                                className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white text-gray-900"
+                                className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white text-black"
                               >
                                 <option value="" className="text-gray-500">Selecione um chofer...</option>
                                 {availableChofers.map(option => (
@@ -1251,7 +1251,7 @@ export default function MobileTaskModal({ card, isOpen, onClose, permissionType,
                             type="date" 
                             value={collectionDate}
                             onChange={(e) => setCollectionDate(e.target.value)}
-                            className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white text-gray-900"
+                            className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white text-black"
                           />
                         </div>
 
@@ -1261,7 +1261,7 @@ export default function MobileTaskModal({ card, isOpen, onClose, permissionType,
                             type="time" 
                             value={collectionTime}
                             onChange={(e) => setCollectionTime(e.target.value)}
-                            className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white text-gray-900"
+                            className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white text-black"
                           />
                         </div>
 
@@ -1270,7 +1270,7 @@ export default function MobileTaskModal({ card, isOpen, onClose, permissionType,
                           <select 
                             value={billingType}
                             onChange={(e) => setBillingType(e.target.value)}
-                            className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white text-gray-900"
+                            className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white text-black"
                           >
                             <option value="" style={{ color: '#6B7280' }}>Selecione o tipo...</option>
                             <option value="avulso">Avulso</option>
@@ -1293,7 +1293,7 @@ export default function MobileTaskModal({ card, isOpen, onClose, permissionType,
                                 setCollectionValue(formatted);
                               }}
                               placeholder="R$ 0,00"
-                              className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white placeholder-gray-500 text-gray-900"
+                              className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white placeholder-gray-600 text-black"
                             />
                           </div>
                         )}
@@ -1312,7 +1312,7 @@ export default function MobileTaskModal({ card, isOpen, onClose, permissionType,
                               setAdditionalKm(formatted);
                             }}
                             placeholder="R$ 0,00"
-                            className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white placeholder-gray-500 text-gray-900"
+                            className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white placeholder-gray-600 text-black"
                           />
                         </div>
 
@@ -1360,7 +1360,7 @@ export default function MobileTaskModal({ card, isOpen, onClose, permissionType,
                           <select 
                             value={rejectionReason}
                             onChange={(e) => setRejectionReason(e.target.value)}
-                            className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-red-500/50 focus:border-red-500 bg-white"
+                            className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-red-500/50 focus:border-red-500 bg-white text-black"
                           >
                             <option value="" style={{ color: '#6B7280' }}>Selecione um motivo...</option>
                             <option value="cliente_pagamento">Cliente realizou pagamento</option>
@@ -1378,7 +1378,7 @@ export default function MobileTaskModal({ card, isOpen, onClose, permissionType,
                             onChange={(e) => setRejectionObservations(e.target.value)}
                             rows={4}
                             placeholder="Descreva detalhes adicionais sobre a rejeição..."
-                            className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-red-500/50 focus:border-red-500 bg-white resize-none placeholder-gray-500"
+                            className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-red-500/50 focus:border-red-500 bg-white resize-none placeholder-gray-600 text-black"
                           />
                         </div>
 
@@ -1507,7 +1507,7 @@ export default function MobileTaskModal({ card, isOpen, onClose, permissionType,
                             onChange={(e) => setUnlockObservations(e.target.value)}
                             rows={3}
                             placeholder="Observações adicionais (opcional)..."
-                            className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 bg-white resize-none placeholder-gray-500"
+                            className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500 bg-white resize-none placeholder-gray-600 text-black"
                           />
                         </div>
 
@@ -1555,7 +1555,7 @@ export default function MobileTaskModal({ card, isOpen, onClose, permissionType,
                           <select 
                             value={towingReason}
                             onChange={(e) => setTowingReason(e.target.value)}
-                            className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-orange-500/50 focus:border-orange-500 bg-white"
+                            className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-orange-500/50 focus:border-orange-500 bg-white text-black"
                           >
                             <option value="" style={{ color: '#6B7280' }}>Selecione o motivo...</option>
                             <option value="Veículo com avarias / problemas mecânicos">Veículo com avarias / problemas mecânicos</option>
@@ -1609,7 +1609,7 @@ export default function MobileTaskModal({ card, isOpen, onClose, permissionType,
                             onChange={(e) => setTowingObservations(e.target.value)}
                             rows={3}
                             placeholder="Observações adicionais (opcional)..."
-                            className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-orange-500/50 focus:border-orange-500 bg-white resize-none placeholder-gray-500"
+                            className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-orange-500/50 focus:border-orange-500 bg-white resize-none placeholder-gray-600 text-black"
                           />
                         </div>
 
@@ -1657,7 +1657,7 @@ export default function MobileTaskModal({ card, isOpen, onClose, permissionType,
                           <select 
                             value={problemType}
                             onChange={(e) => setProblemType(e.target.value)}
-                            className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-purple-500/50 focus:border-purple-500 bg-white"
+                            className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-purple-500/50 focus:border-purple-500 bg-white text-black"
                           >
                             <option value="" style={{ color: '#6B7280' }}>Selecione a dificuldade...</option>
                             <option value="cliente_regularizou">Cliente regularizou o pagamento</option>
@@ -1865,7 +1865,7 @@ export default function MobileTaskModal({ card, isOpen, onClose, permissionType,
                                           setPatioExpenseValues(prev => ({ ...prev, [expense.key]: formatted }));
                                         }}
                                         placeholder="R$ 0,00"
-                                        className="w-full p-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 placeholder-gray-500"
+                                        className="w-full p-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 placeholder-gray-600 text-black"
                                       />
                                     </div>
                                     <div>
@@ -1997,7 +1997,7 @@ export default function MobileTaskModal({ card, isOpen, onClose, permissionType,
                                           setTowedExpenseValues(prev => ({ ...prev, [expense.key]: formatted }));
                                         }}
                                         placeholder="R$ 0,00"
-                                        className="w-full p-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-orange-500/50 focus:border-orange-500 placeholder-gray-500"
+                                        className="w-full p-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-orange-500/50 focus:border-orange-500 placeholder-gray-600 text-black"
                                       />
                                     </div>
                                     <div>
@@ -2070,7 +2070,7 @@ export default function MobileTaskModal({ card, isOpen, onClose, permissionType,
                             onChange={(e) => setMechanicalTowReason(e.target.value)}
                             rows={6}
                             placeholder="Descreva detalhadamente os problemas mecânicos identificados após o pedido de desbloqueio que justificam a necessidade do guincho..."
-                            className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-red-500/50 focus:border-red-500 bg-white resize-none placeholder-gray-500"
+                          className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-red-500/50 focus:border-red-500 bg-white resize-none placeholder-gray-600 text-black"
                           />
                         </div>
 


### PR DESCRIPTION
This commit changes the text color for all input fields, select boxes, and text areas in the various task modals to improve readability and contrast.

Based on user feedback, the font color for user-entered text is now black, and the placeholder text has been changed to a darker gray.

These changes have been applied to both the desktop (`CardModal.tsx`) and mobile (`MobileTaskModal.tsx`) components for a consistent user experience.