### PR TITLE
This commit introduces two main changes to the 'alocar chofer' (alloc…

### DIFF
--- a/components/CardModal.tsx
+++ b/components/CardModal.tsx
@@ -22,7 +22,7 @@ interface CardModalProps {
   onClose: () => void;
   permissionType?: string;
   onUpdateChofer?: (cardId: string, newName: string, newEmail: string) => Promise<void>;
-  onAllocateDriver?: (cardId: string, driverName: string, driverEmail: string, dateTime: string, collectionValue: string, additionalKm: string) => Promise<void>;
+  onAllocateDriver?: (cardId: string, driverName: string, driverEmail: string, dateTime: string, collectionValue: string, additionalKm: string, billingType: string) => Promise<void>;
   onRejectCollection?: (cardId: string, reason: string, observations: string) => Promise<void>;
   onUnlockVehicle?: (cardId: string, phase: string, photos: Record<string, File>, observations?: string) => Promise<void>;
   onRequestTowing?: (cardId: string, phase: string, reason: string, photos: Record<string, File>) => Promise<void>;
@@ -288,7 +288,7 @@ export default function CardModal({ card, onClose, permissionType, onUpdateChofe
       // Valor da recolha (apenas se for faturamento avulso)
       const finalCollectionValue = billingType === 'avulso' ? collectionValue : '';
       
-      await onAllocateDriver(card.id, allocateDriverName, allocateDriverEmail, dateTimeString, finalCollectionValue, additionalKm);
+      await onAllocateDriver(card.id, allocateDriverName, allocateDriverEmail, dateTimeString, finalCollectionValue, additionalKm, billingType);
       
       setFeedback('Chofer alocado com sucesso! Os dados serão atualizados em até 3 minutos.');
       setTimeout(() => {
@@ -1427,6 +1427,7 @@ export default function CardModal({ card, onClose, permissionType, onUpdateChofe
                           )}
 
                           {/* Km Adicional */}
+                          {billingType === 'avulso' && (
                           <div>
                             <label className="text-sm font-bold text-gray-700 mb-2 block" style={{ fontFamily: 'Inter, sans-serif' }}>
                               Km Adicional *
@@ -1447,6 +1448,7 @@ export default function CardModal({ card, onClose, permissionType, onUpdateChofe
                               className="w-full p-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-green-500/50 focus:border-green-500 bg-white shadow-sm transition-all duration-200 text-black placeholder-gray-600"
                             />
                           </div>
+                          )}
 
                           {feedback && (
                             <div className={`text-sm text-center p-3 rounded-lg font-medium ${

--- a/components/KanbanBoard.tsx
+++ b/components/KanbanBoard.tsx
@@ -345,8 +345,8 @@ export default function KanbanBoard({ initialCards, permissionType, onUpdateStat
     }
   };
 
-  const handleAllocateDriver = async (cardId: string, driverName: string, driverEmail: string, dateTime: string, collectionValue: string, additionalKm: string) => {
-    logger.log('Alocando chofer:', { cardId, driverName, driverEmail, dateTime, collectionValue, additionalKm });
+  const handleAllocateDriver = async (cardId: string, driverName: string, driverEmail: string, dateTime: string, collectionValue: string, additionalKm: string, billingType: string) => {
+    logger.log('Alocando chofer:', { cardId, driverName, driverEmail, dateTime, collectionValue, additionalKm, billingType });
     
     try {
       const supabase = createClient();
@@ -383,6 +383,10 @@ export default function KanbanBoard({ initialCards, permissionType, onUpdateStat
         {
           fieldId: "ve_culo_ser_recolhido",
           value: "Sim"
+        },
+        {
+          fieldId: "tipo_de_faturamento",
+          value: billingType
         }
       ];
 


### PR DESCRIPTION
…ate driver) functionality:

1.  The 'tipo_de_faturamento' (billing type) selected in the frontend form is now sent to the Pipefy API. This was achieved by updating the `handleAllocateDriver` function to include the billing type in the GraphQL mutation.

2.  The 'Km Adicional' (Additional Km) field in the form is now only displayed when the 'Tipo de Faturamento' is 'Avulso' (Per-instance). This was implemented using conditional rendering in the `CardModal.tsx` component.